### PR TITLE
Sequel filtering of the form User[:name => 'bob']

### DIFF
--- a/lib/friendly_id/sequel_adapter/configuration.rb
+++ b/lib/friendly_id/sequel_adapter/configuration.rb
@@ -1,0 +1,38 @@
+module FriendlyId
+  module SequelAdapter
+
+    # Extends FriendlyId::Configuration with some implementation details and
+    # features specific to Sequel.
+    class Configuration < FriendlyId::Configuration
+
+      # An array of classes for which the configured class serves as a
+      # FriendlyId scope.
+      attr_reader :child_scopes
+
+      def child_scopes
+        @child_scopes ||= associated_friendly_classes.select do |klass|
+          klass.friendly_id_config.scopes_over?(configured_class)
+        end
+      end
+
+      def scopes_over?(klass)
+        scope? && scope == klass.to_s.underscore.to_sym
+      end
+
+      def scope_for(record)
+        scope? ? record.send(scope).friendly_id : nil
+      end
+
+      private
+
+      def associated_friendly_classes
+        configured_class.association_reflections.values.map{ |association|
+          association[:class_name].constantize
+        }.select { |klass| 
+          klass.respond_to?(:friendly_id_config)
+        }
+      end
+    end
+  end
+end
+

--- a/lib/friendly_id/sequel_adapter/slug.rb
+++ b/lib/friendly_id/sequel_adapter/slug.rb
@@ -11,6 +11,14 @@ module FriendlyId
         sluggable.slug == self
       end
 
+      def self.similar_to(slug)
+        filter({
+          :name           => slug.name,
+          :scope          => slug.scope,
+          :sluggable_type => slug.sluggable_type
+        }).order(:sequence.asc).all
+      end
+
       private
 
       def sluggable

--- a/lib/friendly_id/sequel_adapter/slug.rb
+++ b/lib/friendly_id/sequel_adapter/slug.rb
@@ -35,7 +35,7 @@ module FriendlyId
       def next_sequence
         enable_name_reversion
         conditions =  { :name => name, :scope => scope, :sluggable_type => sluggable_type }
-        prev = self.class.filter(conditions).order("sequence DESC").first
+        prev = self.class.filter(conditions).order(:sequence.desc).first
         prev ? prev.sequence.succ : 1
       end
 

--- a/lib/friendly_id/sequel_adapter/slugged_model.rb
+++ b/lib/friendly_id/sequel_adapter/slugged_model.rb
@@ -10,7 +10,7 @@ module FriendlyId
           :class => slug_class,
           :key => "sluggable_id",
           :conditions => {:sluggable_type => "#{base.to_s}"},
-          :order => "id DESC"
+          :order => :id.desc
         def base.[](*args)
           if args.size == 1
             return super if args.first.kind_of?(Hash) or args.first.unfriendly_id?

--- a/lib/friendly_id/sequel_adapter/slugged_model.rb
+++ b/lib/friendly_id/sequel_adapter/slugged_model.rb
@@ -13,7 +13,7 @@ module FriendlyId
           :order => "id DESC"
         def base.[](*args)
           if args.size == 1
-            return super if args.first.unfriendly_id?
+            return super if args.first.kind_of?(Hash) or args.first.unfriendly_id?
             name, sequence = args.first.to_s.parse_friendly_id
             join_conditions = [:slugs, {:sluggable_id => :id, :sluggable_type => self.to_s}]
             conditions = {:name.qualify("slugs") => name, :sequence.qualify("slugs") => sequence}

--- a/lib/friendly_id_sequel.rb
+++ b/lib/friendly_id_sequel.rb
@@ -1,4 +1,5 @@
 require "sequel"
+require 'friendly_id/sequel_adapter/configuration'
 require "friendly_id/sequel_adapter/simple_model"
 require "friendly_id/sequel_adapter/slugged_model"
 require "friendly_id/sequel_adapter/create_slugs"
@@ -17,7 +18,7 @@ module Sequel
 
       def self.configure(model, method, opts={})
         model.instance_eval do
-          self.friendly_id_config = ::FriendlyId::Configuration.new(model, method, opts)
+          self.friendly_id_config = ::FriendlyId::SequelAdapter::Configuration.new(model, method, opts)
           if friendly_id_config.use_slug?
             require "friendly_id/sequel_adapter/slug"
             include ::FriendlyId::SequelAdapter::SluggedModel

--- a/test/basic_slugged_test.rb
+++ b/test/basic_slugged_test.rb
@@ -10,6 +10,11 @@ module FriendlyId
         include FriendlyId::Test::Slugged
         include FriendlyId::Test::SequelAdapter::Core
         include FriendlyId::Test::SequelAdapter::Slugged
+
+         test "instances should be findable by a hash of options" do
+          instance = klass.send(create_method, :name => "206")
+          assert_equal instance, klass.send(find_method, {:name => "206"})
+        end
       end
     end
   end

--- a/test/scoped_model_test.rb
+++ b/test/scoped_model_test.rb
@@ -1,0 +1,123 @@
+require File.expand_path('../test_helper', __FILE__)
+
+module FriendlyId
+  module Test
+
+    class ScopedModelTest < ::Test::Unit::TestCase
+
+      include FriendlyId::Test::Generic
+      include FriendlyId::Test::Slugged
+      include FriendlyId::Test::SequelAdapter::Core
+      include FriendlyId::Test::SequelAdapter::Slugged
+
+      def setup
+        @homeowner  = HomeOwner.create(:name => "john")
+        @house      = House.create(:name => "123 Main", :home_owner => @homeowner)
+        @usa        = Country.create(:name => "USA")
+        @canada     = Country.create(:name => "Canada")
+        @resident   = Resident.create(:name => "John Smith", :country => @usa)
+        @resident2  = Resident.create(:name => "John Smith", :country => @canada)
+        # @owner      = Company.create(:name => "Acme Events")
+        # @site       = Site.create(:name => "Downtown Venue", :owner => @owner)
+      end
+
+      def teardown
+        Post.delete
+        City.delete
+        FriendlyId::SequelAdapter::Slug.delete
+
+        # Resident.all.destroy!
+        # Country.all.destroy!
+        # User.all.destroy!
+        # House.all.destroy!
+        # Slug.all.destroy!
+      end
+
+      test "a slugged model should auto-detect that it is being used as a parent scope" do
+        assert_equal [Resident], Country.friendly_id_config.child_scopes
+      end
+
+      test "a child model should contain the scope of its parent" do
+        assert_equal "usa", @resident.slugs.first.scope
+      end
+
+      test "a slugged model should update its child model's scopes when its friendly_id changes" do
+        @usa.update(:name => "United States")
+        assert_equal "united-states", @usa.friendly_id
+        assert_equal "united-states", @resident.reload.slugs.first.scope
+      end
+
+      test "a non-slugged model should auto-detect that it is being used as a parent scope" do
+        assert_equal [House], HomeOwner.friendly_id_config.child_scopes
+      end
+
+      test "should update the slug when the scope changes" do
+        @resident.update :country => Country.create(:name => "Argentina")
+        assert_equal "argentina", @resident.reload.slugs.first.scope
+      end
+
+      test "updating only the scope should not append sequence to friendly_id" do
+        old_friendly_id = @resident.friendly_id
+        @resident.update :country => Country.create(:name => "Argentina")
+        assert_equal old_friendly_id, @resident.friendly_id
+      end
+
+      test "updating the scope should increment sequence to avoid conflicts" do
+        old_friendly_id = @resident.friendly_id
+        @resident.update :country => @canada
+        assert_equal "#{old_friendly_id}--2", @resident.friendly_id
+        assert_equal "canada", @resident.reload.slugs.first.scope
+      end
+
+      test "a non-slugged model should update its child model's scopes when its friendly_id changes" do
+        @homeowner.update(:name => "jack")
+        assert_equal "jack", @homeowner.friendly_id
+        assert_equal "jack", @house.reload.slugs.first.scope
+      end
+
+      test "should should not show the scope in the friendly_id" do
+        assert_equal "john-smith", @resident.friendly_id
+        assert_equal "john-smith", @resident2.friendly_id
+      end
+
+#       test "should find a single scoped record with a scope as a string" do
+#         assert Resident.get(@resident.friendly_id, :scope => @resident.country)
+#       end
+# 
+#       test "should find a single scoped record with a scope" do
+#         assert Resident.get(@resident.friendly_id, :scope => @resident.country)
+#       end
+# 
+#       test "should raise an error when finding a single scoped record with no scope" do
+#         assert_raises DataMapper::ObjectNotFoundError do
+#           Resident.get!(@resident.friendly_id)
+#         end
+#       end
+# 
+#       test "should append scope error info when missing scope causes a find to fail" do
+#         begin
+#           Resident.get!(@resident.friendly_id)
+#           fail "The find should not have succeeded"
+#         rescue DataMapper::ObjectNotFoundError => e
+#           assert_match(/scope expected/i, e.message)
+#         end
+#       end
+# 
+#       test "should append scope error info when the scope value causes a find to fail" do
+#         begin
+#           Resident.get!(@resident.friendly_id, :scope => "badscope")
+#           fail "The find should not have succeeded"
+#         rescue DataMapper::ObjectNotFoundError => e
+#           assert_match(/scope \\"badscope\\"/, e.message)
+#         end
+#       end
+# 
+#       test "should update the sluggable field when a polymorphic relationship exists" do
+#         @site.update(:name => "Uptown Venue")
+#         assert_equal "Uptown Venue", @site.name
+#       end
+# 
+    end
+  end
+end
+

--- a/test/support/models.rb
+++ b/test/support/models.rb
@@ -1,0 +1,81 @@
+%w[books users].each do |table|
+  DB.create_table(table) do
+    primary_key :id, :type => Integer
+    string :name, :unique => true
+    string :note
+  end
+end
+
+class Book < Sequel::Model; end
+class User < Sequel::Model; end
+[Book, User].each do |klass|
+  klass.plugin :friendly_id, :name
+end
+
+%w[animals cities people posts].each do |table|
+  DB.create_table(table) do
+    primary_key :id, :type => Integer
+    string :name
+    string :note
+  end
+end
+
+class Animal < Sequel::Model; end
+class Cat < Animal; end
+class City < Sequel::Model; end
+class Post < Sequel::Model; end
+class Person < Sequel::Model
+  def normalize_friendly_id(string)
+    string.upcase
+  end
+end
+
+[Cat, City, Post, Person].each do |klass|
+  klass.plugin :friendly_id, :name, :use_slug => true
+end
+
+
+
+DB.create_table(:residents) do
+  primary_key :id, :type => Integer
+  string :name
+  integer :country_id
+end
+# A slugged model that uses a scope
+class Resident < Sequel::Model
+  many_to_one :country
+  plugin :friendly_id, :name, :use_slug => true, :scope => :country
+end
+
+DB.create_table(:countries) do
+  primary_key :id, :type => Integer
+  string :name
+end
+# A slugged model used as a scope
+class Country < Sequel::Model
+  one_to_many :residents
+  plugin :friendly_id, :name, :use_slug => true
+end
+
+DB.create_table(:home_owners) do
+  primary_key :id, :type => Integer
+  string :name
+end
+# A model that doesn't use slugs
+class HomeOwner < Sequel::Model
+  plugin :friendly_id, :name
+  one_to_many :house
+end
+
+DB.create_table(:houses) do
+  primary_key :id, :type => Integer
+  string :name
+  integer :home_owner_id
+end
+# A model that uses a non-slugged model for its scope
+class House < Sequel::Model
+  many_to_one :home_owner
+  plugin :friendly_id, :name, :use_slug => true, :scope => :home_owner
+end
+
+

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -17,40 +17,6 @@ require File.expand_path("../slugged", __FILE__)
 DB = Sequel.sqlite
 FriendlyId::SequelAdapter::CreateSlugs.apply(DB, :up)
 
-%w[books users].each do |table|
-  DB.create_table(table) do
-    primary_key :id, :type => Integer
-    string :name, :unique => true
-    string :note
-  end
-end
-
-class Book < Sequel::Model; end
-class User < Sequel::Model; end
-[Book, User].each do |klass|
-  klass.plugin :friendly_id, :name
-end
-
-%w[animals cities people posts].each do |table|
-  DB.create_table(table) do
-    primary_key :id, :type => Integer
-    string :name
-    string :note
-  end
-end
-
-class Animal < Sequel::Model; end
-class Cat < Animal; end
-class City < Sequel::Model; end
-class Post < Sequel::Model; end
-class Person < Sequel::Model
-  def normalize_friendly_id(string)
-    string.upcase
-  end
-end
-
-[Cat, City, Post, Person].each do |klass|
-  klass.plugin :friendly_id, :name, :use_slug => true
-end
+require File.expand_path('../support/models', __FILE__)
 
 DB.loggers << Logger.new($stdout) if ENV["LOG"]


### PR DESCRIPTION
In Sequel it's possible to filter datasets using the form User[:name => 'bob'].  This small patch allows this to continue to work with Friendly id.
Test included.
